### PR TITLE
Store credentials in a separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ Exit status | Meaning
 ----------: | :---------
 0           | Everything went properly
 1           | Goal not found
-2           | Invalid day argument
-3           | Datum is not a number
-4           | Wrong number of arguments
+2           | Configuration file not found
+3           | Invalid day argument
+4           | Datum is not a number
+5           | Wrong number of arguments
 
 Errors are checked in descending order, so if multiple errors exist, the largest
 exit status takes precedence.  

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ Tells when datapoint has been created.
 `<day>` should be the day of the month or `^` for today.  Multiple `^` (e.g. 
 `^^` for yesterday) are not supported.  
 
+### Configuration File
+The username and API key to be used for the transaction
+should be stored in a configuration file, `~/.beeminder` by default.
+The format should be a shell script which puts the credentials in the variables
+`key`, and `user`.
+e.g.
+```
+# ~/.beeminder
+------
+user='some_user_name'
+key='Jqt6szDj5WJfm2YyBANU'
+```
+
 ### Viewing goal status
 ```
 > bee <goal>

--- a/bee
+++ b/bee
@@ -12,7 +12,7 @@ function check_data() {
 if [[ ! $data =~ ^-?[0-9]+(\.[0-9]+)?$ ]]
 then
     echo "data must be a number" >&2
-    exit 3
+    exit 4
 fi
 }
 
@@ -37,7 +37,7 @@ else
     if [[ $? != 0 ]]
     then
         # invalid date
-        exit 2
+        exit 3
     fi
 fi
 }
@@ -73,7 +73,7 @@ function get_credentials() {
         . ~/.beeminder
     else
         echo "Credential file ~/.beeminder not found" >&2
-        exit 5
+        exit 2
     fi
 }
 
@@ -96,6 +96,6 @@ case $# in
     * )
         # wrong number of arguments
         echo "Usage: $(basename $0) <goal> <day> <datum> [comment]" >&2
-        exit 4
+        exit 5
     ;;
 esac

--- a/bee
+++ b/bee
@@ -1,8 +1,6 @@
 #! /bin/bash
 
 base='https://www.beeminder.com/api/v1/'
-# user=''
-# key=''
 
 goal=$1
 date=$2
@@ -69,17 +67,29 @@ function goal_status() {
 curl -s "${base}users/${user}/goals/${goal}.json?auth_token=${key}" |sed 's/^.*\"headsum\":\"\([^"]*\)\".*$/\1\n/'
 }
 
+function get_credentials() {
+    if [[ -e ~/.beeminder ]]
+    then
+        . ~/.beeminder
+    else
+        echo "Credential file ~/.beeminder not found" >&2
+        exit 5
+    fi
+}
+
 case $# in
     3|4 )
         # submit data point
         check_data 
         process_date 
+        get_credentials
         check_goal 
         submit 
         exit 0    
     ;;
     1 )
         # get goal status
+        get_credentials
         check_goal
         goal_status
     ;;


### PR DESCRIPTION
Put credentials (username and API token) into a configuration file rather than storing them in the script itself.  This reduces the likelihood of the token accidentally getting uploaded somewhere.  This necessitated addition of a new error code in the case that the credential file is not found, which required rearrangement of existing error codes to maintain descending order of checks.  Obviously this will break anything relying on the exit status, but nothing does that.